### PR TITLE
Fix a deprecation warning in Django 2.0

### DIFF
--- a/djpaddle/urls.py
+++ b/djpaddle/urls.py
@@ -2,6 +2,8 @@ from django.urls import path
 
 from . import views
 
+app_name = 'djpaddle'
+
 urlpatterns = [
     path("webhook/", views.paddle_webhook_view, name="webhook"),
 ]


### PR DESCRIPTION
Django 2 requires an app_name variable to be set on urls.py when using include().

https://stackoverflow.com/questions/48608894/impropyconfigurederror-about-app-name-when-using-namespace-in-include