### PR TITLE
TravisCI fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ pip-log.txt
 .tox
 coverage.xml
 htmlcov/
+cover/
 
 # Translations
 *.mo

--- a/djpaddle/models.py
+++ b/djpaddle/models.py
@@ -24,7 +24,7 @@ class Price(PaddleBaseModel):
     recurring = models.BooleanField()
 
     def __str__(self):
-        return " ".join([str(self.quantity), self.currency])
+        return "{} {}".format(self.quantity, self.currency)
 
     class Meta:
         ordering = ["currency", "recurring"]

--- a/djpaddle/settings.py
+++ b/djpaddle/settings.py
@@ -8,12 +8,15 @@ DJPADDLE_API_BASE = getattr(
     settings, "DJPADDLE_API_BASE", "https://vendors.paddle.com/api/2.0/"
 )
 
-
 # can be found at https://vendors.paddle.com/authentication
-DJPADDLE_VENDOR_ID = getattr(settings, "DJPADDLE_VENDOR_ID", None)
+DJPADDLE_VENDOR_ID = getattr(settings, "DJPADDLE_VENDOR_ID")
+if not DJPADDLE_VENDOR_ID:
+    raise ImproperlyConfigured("'DJPADDLE_VENDOR_ID' must be set")
 
 # create one at https://vendors.paddle.com/authentication
-DJPADDLE_API_KEY = getattr(settings, "DJPADDLE_API_KEY", None)
+DJPADDLE_API_KEY = getattr(settings, "DJPADDLE_API_KEY")
+if not DJPADDLE_API_KEY:
+    raise ImproperlyConfigured("'DJPADDLE_API_KEY' must be set")
 
 # can be found at https://vendors.paddle.com/public-key
 DJPADDLE_PUBLIC_KEY = getattr(settings, "DJPADDLE_PUBLIC_KEY")
@@ -57,9 +60,10 @@ def get_subscriber_model():
             "that has not been installed.".format(model=model_name)
         )
 
-    if (
-        "email" not in [field_.name for field_ in subscriber_model._meta.get_fields()]
-    ) and not hasattr(subscriber_model, "email"):
+    subscriber_field_names = [
+        field_.name for field_ in subscriber_model._meta.get_fields()
+    ]
+    if "email" not in subscriber_field_names and not hasattr(subscriber_model, "email"):
         raise ImproperlyConfigured(
             "DJPADDLE_SUBSCRIBER_MODEL must have an email attribute."
         )

--- a/djpaddle/settings.py
+++ b/djpaddle/settings.py
@@ -22,7 +22,7 @@ if DJPADDLE_PUBLIC_KEY is None:
 try:
     DJPADDLE_KEY = convert_pubkey_to_rsa(DJPADDLE_PUBLIC_KEY)
 except Exception as e:
-    msg = f"failed to convert 'DJPADDLE_PUBLIC_KEY'; original message: {e}"
+    msg = "failed to convert 'DJPADDLE_PUBLIC_KEY'; original message: {}".format(e)
     raise ImproperlyConfigured(msg)
 
 DJPADDLE_SUBSCRIBER_MODEL = getattr(

--- a/djpaddle/settings.py
+++ b/djpaddle/settings.py
@@ -16,8 +16,8 @@ DJPADDLE_VENDOR_ID = getattr(settings, "DJPADDLE_VENDOR_ID", None)
 DJPADDLE_API_KEY = getattr(settings, "DJPADDLE_API_KEY", None)
 
 # can be found at https://vendors.paddle.com/public-key
-DJPADDLE_PUBLIC_KEY = getattr(settings, "DJPADDLE_PUBLIC_KEY", None)
-if DJPADDLE_PUBLIC_KEY is None:
+DJPADDLE_PUBLIC_KEY = getattr(settings, "DJPADDLE_PUBLIC_KEY")
+if not DJPADDLE_PUBLIC_KEY:
     raise ImproperlyConfigured("'DJPADDLE_PUBLIC_KEY' must be set")
 try:
     DJPADDLE_KEY = convert_pubkey_to_rsa(DJPADDLE_PUBLIC_KEY)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,9 @@ settings.configure(
         "djpaddle",
     ],
     SITE_ID=1,
-    DJPADDLE_PUBLIC_KEY=os.environ.get("DJPADDLE_PUBLIC_KEY", ""),
+    DJPADDLE_VENDOR_ID="test-vendor-id",
+    DJPADDLE_API_KEY="test-api-key",
+    DJPADDLE_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCtxEMePySQV6szQ+T6wAkv8Nhz\nxpUw1XzwpHkh5FU2TiPBbcyqL1sBWJeHsFY3jMnzohpajp4v11B9D5WisUvbyjIU\nnYbyU3qDzKe85nPA6gyASvsWW4mdVruVhqMxnoUj2o+H0KWbIdMJWMLF8pPqjynP\nxZHZ9ITbPXpwDtaMUQIDAQAB\n-----END PUBLIC KEY-----",  # NOQA
 )
 django_setup()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,7 +27,7 @@ class TestModelStrs(TestCase):
         price = Price.objects.create(
             plan=plan, currency=currency, quantity=quantity, recurring=True
         )
-        price_string = f"{quantity} {currency}"
+        price_string = "{} {}".format(quantity, currency)
         self.assertEqual(str(price), price_string)
 
     def test_subscription_str(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,6 +2,24 @@ import pytest
 from django.core.exceptions import ImproperlyConfigured
 
 
+def test_missing_djpaddle_vendor_id(settings):
+    settings.DJPADDLE_VENDOR_ID = None
+    from djpaddle import settings
+    from importlib import reload
+
+    with pytest.raises(ImproperlyConfigured):
+        reload(settings)
+
+
+def test_missing_djpaddle_api_key(settings):
+    settings.DJPADDLE_API_KEY = None
+    from djpaddle import settings
+    from importlib import reload
+
+    with pytest.raises(ImproperlyConfigured):
+        reload(settings)
+
+
 def test_missing_djpaddle_public_key(settings):
     settings.DJPADDLE_PUBLIC_KEY = None
     from djpaddle import settings

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,10 @@ envlist =
     py38-django{22,30,master}-{postgres,postgres_native_json,mysql,sqlite}
     py37-django22-checkmigrations
     lint
+    checkmigrations
+    makemigrations
+    makemessages
+    docs
 
 [testenv]
 passenv = DJPADDLE_*


### PR DESCRIPTION
I didn't notice last time that Travis runs on every PR, it just doesn't update the PR itself.

There are 3 errors with 2 different errors:
```
  File "/home/travis/build/dj-paddle/dj-paddle/djpaddle/settings.py", line 25
    msg = f"failed to convert 'DJPADDLE_PUBLIC_KEY'; original message: {e}"
                                                                          ^
SyntaxError: invalid syntax
ERROR: InvocationError for command /home/travis/build/dj-paddle/dj-paddle/.tox/py35-django21-postgres/bin/pytest (exited with code 1)
```
This is due to `fstrings` not being implemented in python 3.5.

```
django.core.exceptions.ImproperlyConfigured: failed to convert 'DJPADDLE_PUBLIC_KEY'; original message: RSA key format is not supported
Makefile:58: recipe for target 'html' failed
make: *** [html] Error 2
ERROR: InvocationError for command /usr/bin/make html (exited with code 2)
```
* Inside `docs/conf.py` `DJPADDLE_PUBLIC_KEY` was getting set to an empty string. `os.environ.get("DJPADDLE_PUBLIC_KEY", "")`
* djpaddle/settings.py was doing `if DJPADDLE_PUBLIC_KEY is None:` so not catching an empty string as not set

Fixes:
* Remove any fstrings. It would be nice to use fstrings everywhere but we would have to drop support for python3.5
* I have added checks to make sure `DJPADDLE_VENDOR_ID` and `DJPADDLE_API_KEY` are set 
* Values for these have been added to `docs/conf.py` 
* tox should now run all the commands Travis does - migrations checks and tox etc.